### PR TITLE
Avoid NPE when retrieving assertion attributes and improve loop checks

### DIFF
--- a/services/src/main/java/org/exoplatform/addons/saml/extensions/SAML2ExtendedAuthenticationHandler.java
+++ b/services/src/main/java/org/exoplatform/addons/saml/extensions/SAML2ExtendedAuthenticationHandler.java
@@ -225,13 +225,15 @@ public class SAML2ExtendedAuthenticationHandler extends SAML2AuthenticationHandl
       String userName = nameID.getValue();
       if (!Boolean.parseBoolean((String)handlerConfig.getParameter("USE_NAMEID"))) {
         Set<StatementAbstractType> statements = assertion.getStatements();
+        outerloop:
         for (StatementAbstractType statement : statements) {
           if (statement instanceof AttributeStatementType attributeStatement) {
             List<AttributeStatementType.ASTChoiceType> attList = attributeStatement.getAttributes();
             for (AttributeStatementType.ASTChoiceType obj : attList) {
               AttributeType attr = obj.getAttribute();
-              if (attr.getFriendlyName().equals(handlerConfig.getParameter("SUBJECT_ATTRIBUTE"))) {
+              if (attr.getFriendlyName() != null && attr.getFriendlyName().equals(handlerConfig.getParameter("SUBJECT_ATTRIBUTE"))) {
                 userName = (String)attr.getAttributeValue().get(0);
+                break outerloop;
               }
             }
           }


### PR DESCRIPTION
Before this change, PicketLink checks all assertion attributes. Some IDP providers do not have friendlyName attribute key which leads to NPE that prevents checking others. A break instruction has been added to skip unnecessary checks when the required subject key is retrieved.