### PR TITLE
fix: SAML2 Logout not working - EXO-70293

### DIFF
--- a/packaging/src/main/tomcat/gatein/conf/saml2/picketlink-sp.xml
+++ b/packaging/src/main/tomcat/gatein/conf/saml2/picketlink-sp.xml
@@ -1,6 +1,6 @@
 <PicketLink xmlns="urn:picketlink:identity-federation:config:2.1">
   <PicketLinkSP xmlns="urn:picketlink:identity-federation:config:2.1"
-                ServerEnvironment="tomcat" BindingType="POST" SupportsSignatures="true" LogOutPage="/">
+                ServerEnvironment="tomcat" BindingType="POST" SupportsSignatures="true" LogOutPage="/" LogOutUrl="${gatein.sso.idp.url.logout::/logout}">
     <IdentityURL>${gatein.sso.idp.url}</IdentityURL>
     <ServiceURL>${gatein.sso.sp.url}</ServiceURL>
 


### PR DESCRIPTION
Before this fix, SAML2 logout not working as idp redirection on logout was done on the same url as login This commit allow to configure a logout url in picketlink-sp.xml, and redirect on it during logout process This commit backport the modification in picketlink-sp file to make logout work when addon is used