### PR TITLE
fix: [SAML] Some properties cannot be modified by configuration - EXO-70965

### DIFF
--- a/packaging/src/main/tomcat/gatein/conf/saml2/picketlink-sp.xml
+++ b/packaging/src/main/tomcat/gatein/conf/saml2/picketlink-sp.xml
@@ -22,7 +22,7 @@
         class="org.gatein.sso.agent.saml.PortalSAML2LogOutHandler"/>
     <Handler
         class="org.exoplatform.addons.saml.extensions.SAML2ExtendedAuthenticationHandler">
-      <Option Key="NAMEID_FORMAT" Value="urn:oasis:names:tc:SAML:2.0:nameid-format:persistent"/>
+      <Option Key="NAMEID_FORMAT" Value="${gatein.sso.saml.nameid.format::urn:oasis:names:tc:SAML:2.0:nameid-format:persistent}"/>
       <Option Key="USE_NAMEID" Value="${gatein.sso.saml.use.namedid::true}"/>
       <Option Key="SUBJECT_ATTRIBUTE" Value="${gatein.sso.saml.subject.attribute::uid}"/>
     </Handler>


### PR DESCRIPTION
Before this fix, property name-id cannot be modified by configuration This commit add the property gatein.sso.saml.nameid.format to be able to configure it